### PR TITLE
Changes to enable warning-free build on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,4 +17,8 @@ include(cmake/utils.cmake)
 
 add_subdirectory(third_party)
 add_subdirectory(effcee)
-add_subdirectory(examples)
+
+# Building examples requires gmock. Only include it if tests are enabled.
+if(${EFFCEE_ENABLE_TESTS})
+  add_subdirectory(examples)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(effcee C CXX)
 enable_testing()
 
 option(EFFCEE_SKIP_TESTS "Skip building tests" ${EFFCEE_SKIP_TESTS})
+option(EFFCEE_ENABLE_SAMPLES "Enable building samples" ${EFFCEE_ENABLE_SAMPLES})
+
 if(NOT ${EFFCEE_SKIP_TESTS})
   set(EFFCEE_ENABLE_TESTS ON)
 endif()
@@ -18,7 +20,6 @@ include(cmake/utils.cmake)
 add_subdirectory(third_party)
 add_subdirectory(effcee)
 
-# Building examples requires gmock. Only include it if tests are enabled.
-if(${EFFCEE_ENABLE_TESTS})
+if(${EFFCEE_ENABLE_SAMPLES})
   add_subdirectory(examples)
 endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -41,8 +41,7 @@ function(effcee_default_c_compile_options TARGET)
   else()
     # disable warning C4800: 'int' : forcing value to bool 'true' or 'false'
     # (performance warning)
-    target_compile_options(${TARGET} PRIVATE /wd4800)
-    target_compile_options(${TARGET} PRIVATE /EHsc)
+    target_compile_options(${TARGET} PRIVATE /wd4800 /EHs)
   endif()
 endfunction(effcee_default_c_compile_options)
 

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -42,6 +42,7 @@ function(effcee_default_c_compile_options TARGET)
     # disable warning C4800: 'int' : forcing value to bool 'true' or 'false'
     # (performance warning)
     target_compile_options(${TARGET} PRIVATE /wd4800)
+    target_compile_options(${TARGET} PRIVATE /EHsc)
   endif()
 endfunction(effcee_default_c_compile_options)
 

--- a/effcee/CMakeLists.txt
+++ b/effcee/CMakeLists.txt
@@ -7,7 +7,6 @@ target_include_directories(effcee
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/.. ${EFFCEE_RE2_DIR})
 target_link_libraries(effcee PUBLIC re2 ${CMAKE_THREADS_LIB_INIT})
 
-# TODO(dneto): Avoid installing gtest and gtest_main. ?!
 install(
   FILES
     effcee.h
@@ -17,16 +16,19 @@ install(TARGETS effcee
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
 
-add_executable(effcee-test
-               check_test.cc
-               cursor_test.cc
-               diagnostic_test.cc
-               match_test.cc
-               options_test.cc
-               result_test.cc)
-effcee_default_compile_options(effcee-test)
-target_include_directories(effcee-test PRIVATE
-                           ${gmock_SOURCE_DIR}/include
-                           ${gtest_SOURCE_DIR}/include)
-target_link_libraries(effcee-test PRIVATE effcee gmock gtest_main)
-add_test(NAME effcee-test COMMAND effcee-test)
+# TODO(dneto): Avoid installing gtest and gtest_main. ?!
+if(${EFFCEE_ENABLE_TESTS})
+  add_executable(effcee-test
+                 check_test.cc
+                 cursor_test.cc
+                 diagnostic_test.cc
+                 match_test.cc
+                 options_test.cc
+                 result_test.cc)
+  effcee_default_compile_options(effcee-test)
+  target_include_directories(effcee-test PRIVATE
+                             ${gmock_SOURCE_DIR}/include
+                             ${gtest_SOURCE_DIR}/include)
+  target_link_libraries(effcee-test PRIVATE effcee gmock gtest_main)
+  add_test(NAME effcee-test COMMAND effcee-test)
+endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,3 @@
-# Suppress all warnings from third-party projects.
-set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
-
 set(EFFCEE_THIRD_PARTY_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING
   "Root location of all third_party projects")
 set(EFFCEE_GOOGLETEST_DIR "${EFFCEE_THIRD_PARTY_ROOT_DIR}/googletest" CACHE STRING

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -16,6 +16,15 @@ if(${EFFCEE_ENABLE_TESTS})
 endif()
 
 if (IS_DIRECTORY ${EFFCEE_RE2_DIR})
+
+  if ("${MSVC}")
+  # Disable RE2's Level 4 MSVC warnings:
+  # 4201: nameless struct/union
+  # 4815: zero-sized array in stack
+  # EHs:  Exception handling
+  add_compile_options(/wd4201 /wd4815 /EHs)
+  endif()
+
   add_subdirectory(${EFFCEE_RE2_DIR} re2)
 endif()
 if (NOT TARGET re2)


### PR DESCRIPTION
* If the user does not want to build the effcee tests, and does not have
the gtest and gmock, there is no need to build tests and the example
program.

* The "/EHs" compiler flag is added for MSVC to handle exceptions
without warnings.

* Removing the "-w" compiler option as it causes compilation warnings on Windows.