### PR TITLE
Avoid building samples if asked not to.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,19 @@ else()
   message(STATUS "Configuring Effcee to avoid building tests.")
 endif()
 
+option(EFFCEE_BUILD_SAMPLES "Enable building sample Effcee programs" ON)
+if(${EFFCEE_BUILD_SAMPLES})
+  message(STATUS "Configuring Effcee to build samples.")
+else()
+  message(STATUS "Configuring Effcee to avoid building samples.")
+endif()
+
 include(cmake/setup_build.cmake)
 include(cmake/utils.cmake)
 
 add_subdirectory(third_party)
 add_subdirectory(effcee)
-add_subdirectory(examples)
+
+if(${EFFCEE_BUILD_SAMPLES})
+  add_subdirectory(examples)
+endif()


### PR DESCRIPTION
This will give users more flexibility on what they want to build.