### PR TITLE
Remove Check::Description method

### DIFF
--- a/effcee/check.cc
+++ b/effcee/check.cc
@@ -51,17 +51,6 @@ Type TypeForSuffix(StringPiece suffix) {
   assert(pair_iter != type_str_table.end());
   return pair_iter->second;
 }
-
-StringPiece SuffixForType(Type type) {
-  const auto& type_str_table = TypeStringTable();
-  const auto pair_iter =
-      std::find_if(type_str_table.begin(), type_str_table.end(),
-                   [type](const std::pair<StringPiece, Type>& elem) {
-                     return type == elem.second;
-                   });
-  assert(pair_iter != type_str_table.end());
-  return pair_iter->first;
-}
 }  // namespace
 
 namespace effcee {
@@ -137,12 +126,6 @@ bool Check::Matches(StringPiece* input, StringPiece* captured,
   }
 
   return matched;
-}
-
-std::string Check::Description(const Options& options) const {
-  std::ostringstream out;
-  out << options.prefix() << SuffixForType(type()) << ": " << param();
-  return out.str();
 }
 
 namespace {

--- a/effcee/check.h
+++ b/effcee/check.h
@@ -168,9 +168,6 @@ class Check {
   // instance is not default-constructed.
   bool Matches(StringPiece* str, StringPiece* captured, VarMapping* vars) const;
 
-  // Returns a string describing this check.
-  std::string Description(const Options& options) const;
-
  private:
   // The type of check.
   Type type_;

--- a/effcee/check_test.cc
+++ b/effcee/check_test.cc
@@ -279,8 +279,7 @@ TEST_P(CheckMatchTest, Samples) {
   VarMapping vars;
   const bool matched = GetParam().check.Matches(&str, &captured, &vars);
   EXPECT_THAT(matched, Eq(GetParam().expected))
-      << "Failed " << GetParam().check.Description(Options()) << " on input "
-      << GetParam().input;
+      << "Failed on input " << GetParam().input;
   EXPECT_THAT(std::string(str.data(), str.size()), Eq(GetParam().remaining));
   EXPECT_THAT(std::string(captured.data(), captured.size()),
               Eq(GetParam().captured));
@@ -313,18 +312,6 @@ INSTANTIATE_TEST_CASE_P(
         {"in hello now", Check(Type::Not, "hello"), true, " now", "hello"},
     }), );
 
-// Check::Description
-TEST(CheckDescription, Samples) {
-  EXPECT_THAT(Check(Type::Simple, "hello").Description(Options()),
-              Eq("CHECK: hello"));
-  EXPECT_THAT(
-      Check(Type::Simple, "magic").Description(Options().SetPrefix("Zing")),
-      Eq("Zing: magic"));
-  EXPECT_THAT(Check(Type::DAG, "now").Description(Options()),
-              Eq("CHECK-DAG: now"));
-  EXPECT_THAT(Check(Type::Next, "it").Description(Options().SetPrefix("Boo")),
-              Eq("Boo-NEXT: it"));
-}
 
 // Check::Part::Regex
 


### PR DESCRIPTION
Error messages are generated by other means, so Check::Description
no longer serves a purpose.