### PR TITLE
Move ::testing::Combine workaround to top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ enable_testing()
 option(EFFCEE_BUILD_TESTING "Enable testing for Effcee" ON)
 if(${EFFCEE_BUILD_TESTING})
   message(STATUS "Configuring Effcee to build tests.")
+  if(MSVC)
+    # Our tests use ::testing::Combine.  Force the ability to use it, working
+    # around googletest's possibly faulty compiler detection logic.
+    # See https://github.com/google/googletest/issues/1352
+    add_definitions(-DGTEST_HAS_COMBINE=1)
+  endif(MSVC)
 else()
   message(STATUS "Configuring Effcee to avoid building tests.")
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -24,11 +24,6 @@ endif()
 
 # Configure third party projects.
 if(EFFCEE_BUILD_TESTING)
-  # Our tests use ::testing::Combine.  Force the ability to use it, working
-  # around googletest's possibly faulty compiler detection logic.
-  # See https://github.com/google/googletest/issues/1352
-  add_definitions(-DGTEST_HAS_COMBINE=1)
-
   if (NOT TARGET gmock)
     if (IS_DIRECTORY ${EFFCEE_GOOGLETEST_DIR})
       add_subdirectory(${EFFCEE_GOOGLETEST_DIR} googletest)


### PR DESCRIPTION
The fix must be visible to compilation in the effcee/ tree
as well.