### PR TITLE
Require VS 2015 or later

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,9 +5,8 @@
 version: "{build}"
 
 os:
-  - Visual Studio 2013
-  - Visual Studio 2015
   - Visual Studio 2017
+  - Visual Studio 2015
 
 platform:
   - x64
@@ -23,8 +22,6 @@ branches:
 matrix:
   fast_finish: true
   exclude:
-    - os: Visual Studio 2013
-      configuration: Debug
     - os: Visual Studio 2015
       configuration: Debug
 
@@ -34,7 +31,6 @@ install:
   - git clone --depth=1 https://github.com/google/re2.git             third_party/re2
 
 before_build:
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64)
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ On Linux, if cross compiling to Windows:
 
 On Windows, the following tools should be installed and available on your path:
 
-- Visual Studio 2013 Update 4 or later. Previous versions of Visual Studio
-  will likely work but are untested.
+- Visual Studio 2015 or later. Previous versions of Visual Studio are not usable
+  with RE2.
 - Git - including the associated tools, Bash, `diff`.
 
 ### Build options


### PR DESCRIPTION
- Update the README
- Disable VS 2013 testing

RE2 dropped support for VS 2013.
See https://github.com/google/re2/commit/97957299d1c9f7617cfe653f344536d733582d9e