### PR TITLE
Add Bazel build rules.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,91 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# Description:
+#
+# Effcee is a C++ library for stateful pattern matching of strings inspired by
+# LLVM's FileCheck.
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files([
+    "CHANGES",
+    "LICENSE",
+])
+
+cc_library(
+    name = "effcee",
+    srcs = glob(
+        ["effcee/*.cc"],
+        exclude = ["effcee/*_test.cc"],
+    ),
+    hdrs = glob(["effcee/*.h"]),
+    compatible_with = [
+    ],
+    deps = [
+        "@com_googlesource_code_re2//:re2",
+    ],
+)
+
+# Tests
+
+cc_test(
+    name = "check_test",
+    srcs = ["effcee/check_test.cc"],
+    deps = [
+        ":effcee",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "cursor_test",
+    srcs = ["effcee/cursor_test.cc"],
+    deps = [
+        ":effcee",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "diagnostic_test",
+    srcs = ["effcee/diagnostic_test.cc"],
+    deps = [
+        ":effcee",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "match_test",
+    srcs = ["effcee/match_test.cc"],
+    deps = [
+        ":effcee",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "options_test",
+    srcs = ["effcee/options_test.cc"],
+    deps = [
+        ":effcee",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "result_test",
+    srcs = ["effcee/result_test.cc"],
+    deps = [
+        ":effcee",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/DEVELOPMENT.howto.md
+++ b/DEVELOPMENT.howto.md
@@ -1,54 +1,55 @@
 # Developing for Effcee
 
-Thank you for considering Effcee development!  Please make sure you review
+Thank you for considering Effcee development! Please make sure you review
 [`CONTRIBUTING.md`](CONTRIBUTING.md) for important preliminary info.
 
 ## Building
 
 Instructions for first-time building can be found in [`README.md`](README.md).
-Incremental build after a source change can be done using `ninja` (or
+Incremental build after a source change can be done using `bazel` or `ninja` (or
 `cmake --build`) and `ctest` exactly as in the first-time procedure.
 
 ## Issue tracking
 
-We use GitHub issues to track bugs, enhancement requests, and questions.
-See [the project's Issues page](https://github.com/google/effcee/issues).
+We use GitHub issues to track bugs, enhancement requests, and questions. See
+[the project's Issues page](https://github.com/google/effcee/issues).
 
 For all but the most trivial changes, we prefer that you file an issue before
-submitting a pull request.  An issue gives us context for your change: what
-problem are you solving, and why.  It also allows us to provide feedback on
-your proposed solution before you invest a lot of effort implementing it.
+submitting a pull request. An issue gives us context for your change: what
+problem are you solving, and why. It also allows us to provide feedback on your
+proposed solution before you invest a lot of effort implementing it.
 
 ## Code reviews
 
 All submissions are subject to review via the GitHub pull review process.
 Reviews will cover:
 
-* *Correctness:* Does it work?  Does it work in a multithreaded context?
-* *Testing:* New functionality should be accompanied by tests.
-* *Testability:* Can it easily be tested?  This is proven with accompanying tests.
-* *Design:* Is the solution fragile? Does it fit with the existing code?
-  Would it easily accommodate anticipated changes?
-* *Ease of use:* Can a client get their work done with a minimum of fuss?
-  Are there unnecessarily surprising details?
-* *Consistency:* Does it follow the style guidelines and the rest of the code?
-  Consistency reduces the work of future readers and maintainers.
-* *Portability:* Does it work in many environments?
+*   *Correctness:* Does it work? Does it work in a multithreaded context?
+*   *Testing:* New functionality should be accompanied by tests.
+*   *Testability:* Can it easily be tested? This is proven with accompanying
+    tests.
+*   *Design:* Is the solution fragile? Does it fit with the existing code? Would
+    it easily accommodate anticipated changes?
+*   *Ease of use:* Can a client get their work done with a minimum of fuss? Are
+    there unnecessarily surprising details?
+*   *Consistency:* Does it follow the style guidelines and the rest of the code?
+    Consistency reduces the work of future readers and maintainers.
+*   *Portability:* Does it work in many environments?
 
 To respond to feedback, submit one or more *new* commits to the pull request
 branch. The project maintainer will normally clean up the submission by
-squashing feedback response commits.  We maintain a linear commit history,
-so submission will be rebased onto master before merging.
+squashing feedback response commits. We maintain a linear commit history, so
+submission will be rebased onto master before merging.
 
 ## Testing
 
 There is a lot we won't say about testing. However:
 
-* Most tests should be small scale, i.e. unit tests.
-* Tests should run quickly.
-* A test should:
-  * Check a single behaviour.  This often corresponds to a use case.
-  * Have a three phase structure: setup, action, check.
+*   Most tests should be small scale, i.e. unit tests.
+*   Tests should run quickly.
+*   A test should:
+    *   Check a single behaviour. This often corresponds to a use case.
+    *   Have a three phase structure: setup, action, check.
 
 ## Coding style
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 [![Linux and OSX Build Status](https://travis-ci.org/google/effcee.svg)](https://travis-ci.org/google/effcee "Linux and OSX Build Status")
 
-Effcee is a C++ library for stateful pattern matching of strings,
-inspired by LLVM's [FileCheck][FileCheck] command.
+Effcee is a C++ library for stateful pattern matching of strings, inspired by
+LLVM's [FileCheck][FileCheck] command.
 
 Effcee:
-- Is a library, so it can be used for quickly running tests in your own process.
-- Is largely compatible with FileCheck, so tests and test-writing skills are
-  transferable.
-- Has few dependencies:
-  - The C++11 standard library, and
-  - [RE2][RE2] for regular expression matching.
+
+-   Is a library, so it can be used for quickly running tests in your own
+    process.
+-   Is largely compatible with FileCheck, so tests and test-writing skills are
+    transferable.
+-   Has few dependencies:
+    -   The C++11 standard library, and
+    -   [RE2][RE2] for regular expression matching.
 
 ## Example
 
@@ -72,8 +74,8 @@ The following is from [examples/main.cc](examples/main.cc):
 
 ```
 
-For more examples, see the matching tests
-in [effcee/match_test.cc](effcee/match_test.cc).
+For more examples, see the matching tests in
+[effcee/match_test.cc](effcee/match_test.cc).
 
 ## Status
 
@@ -81,55 +83,58 @@ Effcee is mature enough to be relied upon by
 [third party projects](#what-uses-effcee), but could be improved.
 
 What works:
-* All check types: CHECK, CHECK-NEXT, CHECK-SAME, CHECK-DAG, CHECK-LABEL, CHECK-NOT.
-* Check strings can contain:
-  * fixed strings
-  * regular expressions
-  * variable definitions and uses
-* Setting a custom check prefix.
-* Accurate and helpful reporting of match failures.
+
+*   All check types: CHECK, CHECK-NEXT, CHECK-SAME, CHECK-DAG, CHECK-LABEL,
+    CHECK-NOT.
+*   Check strings can contain:
+    *   fixed strings
+    *   regular expressions
+    *   variable definitions and uses
+*   Setting a custom check prefix.
+*   Accurate and helpful reporting of match failures.
 
 What is left to do:
-* Add an option to define shorthands for regular expressions.
-  * For example, you could express that if the string `%%` appears where a
-    regular expression is expected, then it expands to the regular expression
-    for a local identifier in LLVM assembly language, i.e.
-    `%[-a-zA-Z$._][-a-zA-Z$._0-9]*`.
-    This enables you to write precise tests with less fuss.
-* Better error reporting for failure to parse the checks list.
-* Write a check language reference and tutorial.
+
+*   Add an option to define shorthands for regular expressions.
+    *   For example, you could express that if the string `%%` appears where a
+        regular expression is expected, then it expands to the regular
+        expression for a local identifier in LLVM assembly language, i.e.
+        `%[-a-zA-Z$._][-a-zA-Z$._0-9]*`. This enables you to write precise tests
+        with less fuss.
+*   Better error reporting for failure to parse the checks list.
+*   Write a check language reference and tutorial.
 
 What is left to do, but lower priority:
-* Match full lines.
-* Strict whitespace.
-* Implicit check-not.
-* Variable scoping.
+
+*   Match full lines.
+*   Strict whitespace.
+*   Implicit check-not.
+*   Variable scoping.
 
 ## Licensing and contributing
 
-Effcee is licensed under terms of the [Apache 2.0 license](LICENSE).  If you
-are interested in contributing to this project, please see
+Effcee is licensed under terms of the [Apache 2.0 license](LICENSE). If you are
+interested in contributing to this project, please see
 [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 This is not an official Google product (experimental or otherwise), it is just
-code that happens to be owned by Google.  That may change if Effcee gains
-contributions from others.  See the [`CONTRIBUTING.md`](CONTRIBUTING.md) file
-for more information. See also the [`AUTHORS`](AUTHORS) and
+code that happens to be owned by Google. That may change if Effcee gains
+contributions from others. See the [`CONTRIBUTING.md`](CONTRIBUTING.md) file for
+more information. See also the [`AUTHORS`](AUTHORS) and
 [`CONTRIBUTORS`](CONTRIBUTORS) files.
 
 ## File organization
 
-- [`effcee`/](effcee) : library source code, and tests
-- `third_party/`: third party open source packages, downloaded
-  separately
-- [`examples/`](examples): example programs
+-   [`effcee`/](effcee) : library source code, and tests
+-   `third_party/`: third party open source packages, downloaded separately
+-   [`examples/`](examples): example programs
 
 Effcee depends on the [RE2][RE2] regular expression library.
 
 Effcee tests depend on [Googletest][Googletest] and [Python 3][Python].
 
-In the following sections, `$SOURCE_DIR` is the directory containing the
-Effcee source code.
+In the following sections, `$SOURCE_DIR` is the directory containing the Effcee
+source code.
 
 ## Getting and building Effcee
 
@@ -144,17 +149,24 @@ cd $SOURCE_DIR/
 ```
 
 Note: There are two other ways to manage third party sources:
-- If you are building Effcee as part of a larger CMake-based project,
-  add the RE2 and `googletest` projects before adding Effcee.
-- Otherwise, you can set CMake variables to point to third party sources
-  if they are located somewhere else.  See the [Build options](#build-options) below.
+
+-   If you are building Effcee with Bazel (https://bazel.build), you do not need
+    to clone the repositories for `googletest` and `re2`. They will be
+    automatically downloaded by Bazel during build. Bazel will suggest adding
+    `sha256` attributes to each repository rule to get hermetic builds (these
+    notices are safe to ignore if you are not interested in hermetic builds).
+-   If you are building Effcee as part of a larger CMake-based project, add the
+    RE2 and `googletest` projects before adding Effcee.
+-   Otherwise, you can set CMake variables to point to third party sources if
+    they are located somewhere else. See the [Build options](#build-options)
+    below.
 
 2) Ensure you have the requisite tools -- see the tools subsection below.
 
 3) Decide where to place the build output. In the following steps, we'll call it
-   `$BUILD_DIR`. Any new directory should work. We recommend building outside
-   the source tree, but it is also common to build in a (new) subdirectory of
-   `$SOURCE_DIR`, such as `$SOURCE_DIR/build`.
+`$BUILD_DIR`. Any new directory should work. We recommend building outside the
+source tree, but it is also common to build in a (new) subdirectory of
+`$SOURCE_DIR`, such as `$SOURCE_DIR/build`.
 
 4a) Build and test with Ninja on Linux or Windows:
 
@@ -174,9 +186,8 @@ cmake --build . --config {Release|Debug|MinSizeRel|RelWithDebInfo}
 ctest -C {Release|Debug|MinSizeRel|RelWithDebInfo}
 ```
 
-4c) Or build with MinGW on Linux for Windows:
-(Skip building threaded unit tests due to
-[Googletest bug 606](https://github.com/google/googletest/issues/606))
+4c) Or build with MinGW on Linux for Windows: (Skip building threaded unit tests
+due to [Googletest bug 606](https://github.com/google/googletest/issues/606))
 
 ```sh
 cd $BUILD_DIR
@@ -186,19 +197,27 @@ cmake -GNinja -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo} $SOURCE_DIR \
 ninja
 ```
 
-After a successful build, you should have a `libeffcee` library under
-the `$BUILD_DIR/effcee/` directory.
+4d) Or build with Bazel on Linux:
+
+```sh
+cd $SOURCE_DIR
+bazel build -c opt :all
+```
+
+After a successful build, you should have a `libeffcee` library under the
+`$BUILD_DIR/effcee/` directory (or `$SOURCE_DIR/bazel-bin` when building with
+Bazel).
 
 The default behavior on MSVC is to link with the static CRT. If you would like
-to change this behavior `-DEFFCEE_ENABLE_SHARED_CRT` may be passed on the
-cmake configure line.
+to change this behavior `-DEFFCEE_ENABLE_SHARED_CRT` may be passed on the cmake
+configure line.
 
 ### Tests
 
 By default, Effcee registers two tests with `ctest`:
 
-* `effcee-test`: All library tests, based on Googletest.
-* `effcee-example`: Executes the example executable with sample inputs.
+*   `effcee-test`: All library tests, based on Googletest.
+*   `effcee-example`: Executes the example executable with sample inputs.
 
 Running `ctest` without arguments will run the tests for Effcee as well as for
 RE2.
@@ -210,8 +229,8 @@ configuration time:
 cmake -GNinja -DEFFCEE_BUILD_TESTING=OFF ...
 ```
 
-The RE2 tests run much longer, so if you're working on Effcee alone, we
-suggest limiting ctest to tests with prefix `effcee`:
+The RE2 tests run much longer, so if you're working on Effcee alone, we suggest
+limiting ctest to tests with prefix `effcee`:
 
     ctest -R effcee
 
@@ -227,39 +246,42 @@ cmake -GNinja -DRE2_BUILD_TESTING=OFF ...
 For building, testing, and profiling Effcee, the following tools should be
 installed regardless of your OS:
 
-- A compiler supporting C++11.
-- [CMake][CMake]: for generating compilation targets.
-- [Python 3][Python]: for a test script.
+-   A compiler supporting C++11.
+-   [CMake][CMake]: for generating compilation targets.
+-   [Python 3][Python]: for a test script.
 
-On Linux, if cross compiling to Windows:
-- [MinGW][MinGW]: A GCC-based cross compiler targeting Windows
-    so that generated executables use the Microsoft C runtime libraries.
+On Linux, if cross compiling to Windows: - [MinGW][MinGW]: A GCC-based cross
+compiler targeting Windows so that generated executables use the Microsoft C
+runtime libraries.
 
 On Windows, the following tools should be installed and available on your path:
 
-- Visual Studio 2015 or later. Previous versions of Visual Studio are not usable
-  with RE2 or Googletest.
-- Git - including the associated tools, Bash, `diff`.
+-   Visual Studio 2015 or later. Previous versions of Visual Studio are not
+    usable with RE2 or Googletest.
+-   Git - including the associated tools, Bash, `diff`.
 
 ### Build options
 
 Third party source locations:
-- `EFFCEE_GOOGLETEST_DIR`: Location of `googletest` sources, if not under
-  `third_party`.
-- `EFFCEE_RE2_DIR`: Location of `re2` sources, if not under `third_party`.
-- `EFFCEE_THIRD_PARTY_ROOT_DIR`: Alternate location for `googletest` and
-  `re2` subdirectories.  This is used if the sources are not located under
-  the `third_party` directory, and if the previous two variables are not set.
+
+-   `EFFCEE_GOOGLETEST_DIR`: Location of `googletest` sources, if not under
+    `third_party`.
+-   `EFFCEE_RE2_DIR`: Location of `re2` sources, if not under `third_party`.
+-   `EFFCEE_THIRD_PARTY_ROOT_DIR`: Alternate location for `googletest` and `re2`
+    subdirectories. This is used if the sources are not located under the
+    `third_party` directory, and if the previous two variables are not set.
 
 Compilation options:
-- `DISABLE_RTTI`. Disable runtime type information. Default is enabled.
-- `DISABLE_EXCEPTIONS`.  Disable exceptions. Default is enabled.
-- `EFFCEE_ENABLE_SHARED_CRT`. See above.
+
+-   `DISABLE_RTTI`. Disable runtime type information. Default is enabled.
+-   `DISABLE_EXCEPTIONS`. Disable exceptions. Default is enabled.
+-   `EFFCEE_ENABLE_SHARED_CRT`. See above.
 
 Controlling samples and tests:
-- `EFFCEE_BUILD_SAMPLES`. Should Effcee examples be built?  Defaults to `ON`.
-- `EFFCEE_BUILD_TESTING`. Should Effcee tests be built?  Defaults to `ON`.
-- `RE2_BUILD_TESTING`. Should RE2 tests be built?  Defaults to `ON`.
+
+-   `EFFCEE_BUILD_SAMPLES`. Should Effcee examples be built? Defaults to `ON`.
+-   `EFFCEE_BUILD_TESTING`. Should Effcee tests be built? Defaults to `ON`.
+-   `RE2_BUILD_TESTING`. Should RE2 tests be built? Defaults to `ON`.
 
 ## Bug tracking
 
@@ -268,9 +290,9 @@ We track bugs using GitHub -- click on the "Issues" button on
 
 ## What uses Effcee?
 
-- [Tests](https://github.com/Microsoft/DirectXShaderCompiler/tree/master/tools/clang/test/CodeGenSPIRV)
-  for SPIR-V code generation in the [DXC][DXC] HLSL compiler.
-- Tests for [SPIRV-Tools][SPIRV-Tools]
+-   [Tests](https://github.com/Microsoft/DirectXShaderCompiler/tree/master/tools/clang/test/CodeGenSPIRV)
+    for SPIR-V code generation in the [DXC][DXC] HLSL compiler.
+-   Tests for [SPIRV-Tools][SPIRV-Tools]
 
 ## References
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,21 @@
+workspace(name = "effcee")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_cc",
+    strip_prefix = "rules_cc-master",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+)
+
+http_archive(
+    name = "com_google_googletest",
+    strip_prefix = "googletest-master",
+    urls = ["https://github.com/google/googletest/archive/master.zip"],
+)
+
+http_archive(
+    name = "com_googlesource_code_re2",
+    strip_prefix = "re2-master",
+    urls = ["https://github.com/google/re2/archive/master.zip"],
+)


### PR DESCRIPTION
This adds support for building effcee with Bazel (https://bazel.build).

It automatically pulls the googletest and re2 repositories when building
with Bazel.  I did not add a sha256 attribute to fix the version of the
external repos to get, so by default this tracks top-of-master for those
repos.

It's easy to fix the versions by adding the sha256 attribute that Bazel
suggests when it starts.