### PR TITLE
Add effcee-fuzz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ include(cmake/utils.cmake)
 
 add_subdirectory(third_party)
 add_subdirectory(effcee)
+add_subdirectory(fuzzer)
 
 if(${EFFCEE_BUILD_SAMPLES})
   add_subdirectory(examples)

--- a/fuzzer/CMakeLists.txt
+++ b/fuzzer/CMakeLists.txt
@@ -1,0 +1,18 @@
+if (EXISTS "${EFFCEE_FUZZED_DATA_PROVIDER_DIR}/FuzzedDataProvider.h")
+  message(STATUS "effcee: configuring effcee-fuzz")
+  add_executable(effcee-fuzz effcee_fuzz.cc)
+  effcee_default_compile_options(effcee-fuzz)
+  target_include_directories(effcee-fuzz PRIVATE "${EFFCEE_FUZZED_DATA_PROVIDER_DIR}")
+  target_link_libraries(effcee-fuzz PRIVATE effcee)
+
+  if(UNIX AND NOT MINGW)
+    set_target_properties(effcee-fuzz PROPERTIES LINK_FLAGS -pthread)
+  endif()
+  if (WIN32 AND NOT MSVC)
+    # For MinGW cross-compile, statically link to the C++ runtime
+    set_target_properties(effcee-fuzz PROPERTIES
+       LINK_FLAGS "-static -static-libgcc -static-libstdc++")
+  endif(WIN32 AND NOT MSVC)
+else()
+  message(STATUS "effcee: effcee-fuzz won't be built.  Can't find FuzzedDataProvider.h")
+endif()

--- a/fuzzer/effcee_fuzz.cc
+++ b/fuzzer/effcee_fuzz.cc
@@ -1,0 +1,49 @@
+// Copyright 2019 The Effcee Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstdio>
+
+#include "FuzzedDataProvider.h"
+#include "effcee/effcee.h"
+
+// Consumes standard input as a fuzzer input, breaks it apart into text
+// and a check, then  runs a basic match.
+int main(int argc, char* argv[]) {
+  std::vector<uint8_t> input;
+  // Read standard input into a buffer.
+  {
+    if (FILE* fp = freopen(nullptr, "rb", stdin)) {
+      uint8_t chunk[1024];
+      while (size_t len = fread(chunk, sizeof(uint8_t), sizeof(chunk), fp)) {
+        input.insert(input.end(), chunk, chunk + len);
+      }
+      if (ftell(fp) == -1L) {
+        if (ferror(fp)) {
+          fprintf(stderr, "error: error reading standard input");
+        }
+        return 1;
+      }
+    } else {
+      fprintf(stderr, "error: couldn't reopen stdin for binary reading");
+    }
+  }
+
+  // This is very basic, but can find bugs.
+  FuzzedDataProvider stream(input.data(), input.size());
+  std::string text = stream.ConsumeRandomLengthString(input.size());
+  std::string checks = stream.ConsumeRemainingBytesAsString();
+  effcee::Match(text, checks);
+  return 0;
+}


### PR DESCRIPTION
It's only built if you specify a CMake variable pointing
at the FuzzedDataProvider.h source file from LLVM's compiler-rt.

effcee-fuzz runs a simple matcher against standard input.
This can be used to simply and easily reproduce OSS-Fuzz failures.