### PR TITLE
Update Bazel build rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ exports_files([
     "LICENSE",
 ])
 
+## This is the main functionality.
 cc_library(
     name = "effcee",
     srcs = glob(
@@ -28,7 +29,31 @@ cc_library(
     ],
 )
 
-# Tests
+## An example binary showing usage
+cc_binary(
+    name = "effcee_example",
+    srcs = ["examples/main.cc"],
+    deps = [ ":effcee" ],
+)
+
+# Test effcee_example executable
+py_test(
+    name = "effcee_example_test",
+    srcs = ["examples/effcee-example-driver.py"],
+    main = "examples/effcee-example-driver.py",
+    data = [ ":effcee_example", "examples/example_data.txt" ],
+    args = [
+        "$(location effcee_example)",
+        "examples/example_data.txt",
+        "'CHECK: Hello'",
+        "'CHECK-SAME: world'",
+        "'CHECK-NEXT: Bees'",
+        "'CHECK-NOT: Sting'",
+        "'CHECK: Honey'",
+    ],
+)
+
+# Unit tests
 
 cc_test(
     name = "check_test",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,18 +4,20 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_cc",
-    strip_prefix = "rules_cc-master",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+    strip_prefix = "rules_cc-main",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/main.zip"],
 )
 
 http_archive(
     name = "com_google_googletest",
-    strip_prefix = "googletest-master",
-    urls = ["https://github.com/google/googletest/archive/master.zip"],
+    strip_prefix = "googletest-release-1.10.0",
+    urls = ["https://github.com/google/googletest/archive/release-1.10.0.zip"],
+    sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
 )
 
 http_archive(
     name = "com_googlesource_code_re2",
-    strip_prefix = "re2-master",
-    urls = ["https://github.com/google/re2/archive/master.zip"],
+    strip_prefix = "re2-2022-06-01",
+    urls = ["https://github.com/google/re2/archive/2022-06-01.zip"],
+    sha256 = "9f3b65f2e0c78253fcfdfce1754172b0f97ffdb643ee5fd67f0185acf91a3f28",
 )


### PR DESCRIPTION
- Specify specific releases of re2 and googltest dependencies
- Add an 'effcee_example' binary target
- Add an 'effcee_example_test' showing usage of that example binary