### PR TITLE
Update Bazel external dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,21 +3,15 @@ workspace(name = "effcee")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_cc",
-    strip_prefix = "rules_cc-main",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/main.zip"],
-)
-
-http_archive(
     name = "com_google_googletest",
-    strip_prefix = "googletest-release-1.10.0",
-    urls = ["https://github.com/google/googletest/archive/release-1.10.0.zip"],
-    sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
+    strip_prefix = "googletest-release-1.12.1",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip"],
+    sha256 = "24564e3b712d3eb30ac9a85d92f7d720f60cc0173730ac166f27dda7fed76cb2"
 )
 
 http_archive(
     name = "com_googlesource_code_re2",
-    strip_prefix = "re2-2022-06-01",
-    urls = ["https://github.com/google/re2/archive/2022-06-01.zip"],
-    sha256 = "9f3b65f2e0c78253fcfdfce1754172b0f97ffdb643ee5fd67f0185acf91a3f28",
+    strip_prefix = "re2-2022-12-01",
+    urls = ["https://github.com/google/re2/archive/refs/tags/2022-12-01.zip"],
+    sha256 = "0a6cc63356915057f8fceb4224355507e24591dc84eea5c0241b5f57daa02e6f",
 )


### PR DESCRIPTION
Stop using an external rules_cc dependency. Use internal C/C++ rules instead.
- Follows googletest in doing this. https://github.com/google/googletest/pull/3574
- See also: https://github.com/bazelbuild/rules_go/pull/2950 This appears necessary for compatibility with Bazel 5.0.0 and Bazel 6.0.0

Update to googletest-release-1.12.1, the last release that only needs a C++11 compiler, and doesn't require C++14.

Update to re2-2022-12-01

I have successfully built and tested effcee with this configuration on Linux x86-64 with Bazel 5.0.0 and Bazel 6.0.0.