### PR TITLE
Stop forcing c++11 because of re2

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -50,8 +50,8 @@ endfunction(effcee_default_c_compile_options)
 function(effcee_default_compile_options TARGET)
   effcee_default_c_compile_options(${TARGET})
   if (NOT "${MSVC}")
-    # RE2's public header requires C++11.  So publicly required C++11
-    target_compile_options(${TARGET} PUBLIC -std=c++11)
+    # RE2's public header requires C++11.  So publicly require C++11 or higher
+    target_compile_features(re2 PUBLIC cxx_std_11)
     if (NOT EFFCEE_ENABLE_SHARED_CRT)
       if (WIN32)
         # For MinGW cross compile, statically link to the C++ runtime.


### PR DESCRIPTION
Setting -std=c++11 is forcing projects using effcee to use exactly this version of the standard. Some of these projects, such as SPIRV-Tools now require c++17.