### PR TITLE
Avoid hardcoding C++11 requirement at project level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.17.2)
 project(effcee C CXX)
 enable_testing()
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(EFFCEE_BUILD_TESTING "Enable testing for Effcee" ON)
 if(${EFFCEE_BUILD_TESTING})

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -49,9 +49,9 @@ endfunction(effcee_default_c_compile_options)
 
 function(effcee_default_compile_options TARGET)
   effcee_default_c_compile_options(${TARGET})
+  # RE2's public header requires C++11.  So publicly require C++11
+  target_compile_features(${TARGET} PUBLIC cxx_std_11)
   if (NOT "${MSVC}")
-    # RE2's public header requires C++11.  So publicly required C++11
-    target_compile_options(${TARGET} PUBLIC -std=c++11)
     if (NOT EFFCEE_ENABLE_SHARED_CRT)
       if (WIN32)
         # For MinGW cross compile, statically link to the C++ runtime.


### PR DESCRIPTION
Set the requirement for C++11 on the library target. Use target_compile_features, which is new in CMake 3.8

Update minmum CMake to 3.17.2, which is what our bots have installed.