### PR TITLE
Remove iterator diff from two different String Pieces

### DIFF
--- a/effcee/check.cc
+++ b/effcee/check.cc
@@ -118,7 +118,8 @@ bool Check::Matches(StringPiece* input, StringPiece* captured,
                                   captures.get(), num_captures);
   if (matched) {
     *captured = captures[0];
-    input->remove_prefix(captured->end() - input->begin());
+    size_t start_position = input->find(captures[0]);
+    input->remove_prefix(start_position + captures[0].size());
     // Update the variable mapping.
     for (auto& var_def_index : var_def_indices) {
       const int index = var_def_index.first;


### PR DESCRIPTION
The behavious is technically undefined when you take the diff of iterators from two different string views. This is why MSVC will cause an assert in their debug builds.

I modified that code to find the captured string in the input to be able to calculate the length of the prefixe that needs to be removed. It will be much slower, but it avoids the assert.

Fixes #52