### PR TITLE
kokoro: Allow linux image to be set by LINUX_BUILDER_IMAGE

### DIFF
--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -52,7 +52,7 @@ docker run --rm -i \
   --env KOKORO_ARTIFACTS_DIR="${KOKORO_ARTIFACTS_DIR}" \
   --env BUILD_SHA="${BUILD_SHA}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
-  "gcr.io/shaderc-build/radial-build:latest"
+  "${LINUX_BUILDER_IMAGE-gcr.io/shaderc-build/radial-build}"
 RESULT=$?
 
 # This is important. If the permissions are not fixed, kokoro will fail


### PR DESCRIPTION
If LINUX_BUILDER_IMAGE is defined, use that as the URL. Otherwise use the old one.