### PR TITLE
[Kokoro] Use merge-base for format check

### DIFF
--- a/utils/check_code_format.sh
+++ b/utils/check_code_format.sh
@@ -22,7 +22,7 @@
 #    - 'clang-format-diff.py' is in the utils directory, or env var
 #       points to it.CLANG_FORMAT_DIFF
 
-BASE_BRANCH=${1:-main}
+BASE_BRANCH=$(git merge-base main HEAD)
 
 CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
 if [ ! -f "$CLANG_FORMAT" ]; then


### PR DESCRIPTION
When doing the clang format check, the current branch is compared with main to see which files changed, and if there are any formating issues in those files. This can cause false positives if the current branch is too far behind main. If another PR fixed the formating in main, then that will be flagged as an error because it looks like the current PR will undo that change.

The fix is to use the merge-base for main and HEAD to find the first common ancestor of the two to determine which files are changed in the current branch.

Bug: crbug.com/414577655