### PR TITLE
Set Bazel module version  0.1

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = ["//visibility:private"],
 )
 
 # Description:
@@ -12,7 +12,9 @@ licenses(["notice"])  # Apache 2.0
 exports_files([
     "CHANGES",
     "LICENSE",
-])
+],
+    visibility = ["//visibility:public"],
+)
 
 ## This is the main functionality.
 cc_library(
@@ -27,6 +29,7 @@ cc_library(
     deps = [
         "@re2//:re2",
     ],
+    visibility = ["//visibility:public"],
 )
 
 ## An example binary showing usage
@@ -51,6 +54,7 @@ py_test(
         "'CHECK-NOT: Sting'",
         "'CHECK: Honey'",
     ],
+    size = "small",
 )
 
 # Unit tests
@@ -63,6 +67,7 @@ cc_test(
         "@googletest//:gtest_main",
         "@googletest//:gtest",
     ],
+    size = "small",
 )
 
 cc_test(
@@ -73,6 +78,7 @@ cc_test(
         "@googletest//:gtest_main",
         "@googletest//:gtest",
     ],
+    size = "small",
 )
 
 cc_test(
@@ -83,6 +89,7 @@ cc_test(
         "@googletest//:gtest_main",
         "@googletest//:gtest",
     ],
+    size = "small",
 )
 
 cc_test(
@@ -93,6 +100,7 @@ cc_test(
         "@googletest//:gtest_main",
         "@googletest//:gtest",
     ],
+    size = "small",
 )
 
 cc_test(
@@ -103,6 +111,7 @@ cc_test(
         "@googletest//:gtest_main",
         "@googletest//:gtest",
     ],
+    size = "small",
 )
 
 cc_test(
@@ -113,4 +122,5 @@ cc_test(
         "@googletest//:gtest_main",
         "@googletest//:gtest",
     ],
+    size = "small",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,15 @@
-module(name = "effcee")
+module(name = "effcee", version = "0.1")
+"""
+Effcee is a C++ library for stateful pattern matching of strings inspired by
+LLVM's FileCheck.
+"""
 
 bazel_dep(name = "rules_python", version = "0.31.0")
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     configure_coverage_tool = False,
     ignore_root_user_error = True,
-    python_version = "3.11",
+    python_version = "3.12",
 )
 
 bazel_dep(


### PR DESCRIPTION
Bazel changes
- Update to Python 3.12
- Set default visibility to private.  Only the CHANGES and LICENSE, and 'effcee' library are public.
- Set test size to "small"