### PR TITLE
Create Effcee v1.2026.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,8 +24,6 @@ cc_library(
         exclude = ["effcee/*_test.cc"],
     ),
     hdrs = glob(["effcee/*.h"]),
-    compatible_with = [
-    ],
     deps = [
         "@re2//:re2",
     ],

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 Revision history for Effcee
 
+v1.2026.0 2026-08-12
+ - Switch to Semver-compatible 1.<YEAR>.<NUM> versioning.
+ - Use Python 3.12
+ - Use Bazel 8.7, including setting up a proper MODULE.bazel
+
 v2023.0-dev 2020-06-16
  - Add dependency on Abseil
  - Set up Kokoro bots

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.22.1)
-project(effcee C CXX)
+project(effcee
+  VERSION 1.2026.0
+  LANGUAGES C CXX
+  # When upgrading to CMake 4.3, add SPDX_LICENSE Apache-2.0
+)
+
 enable_testing()
 
 # Require at least C++17

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "effcee", version = "0.1")
+module(name = "effcee", version = "1.2026.0")
 """
 Effcee is a C++ library for stateful pattern matching of strings inspired by
 LLVM's FileCheck.


### PR DESCRIPTION
Switch from v<YEAR>.<NUM> versioning to something
more compatible with SemVer.
The Effcee API is stable, so use v1.<YEAR>.<NUM>

Update Bazel and CMake definitions to match.